### PR TITLE
Improve CLI Load Time

### DIFF
--- a/tnco/app/app.py
+++ b/tnco/app/app.py
@@ -32,7 +32,6 @@ from warnings import warn
 import more_itertools as mit
 from pathvalidate import ValidationError, validate_filepath
 
-import tnco.utils.circuit as circuit_utils
 import tnco.utils.tn as tn_utils
 from tnco.app.tn import Tensor, TensorNetwork
 from tnco.typing import Matrix, Qubit
@@ -469,17 +468,18 @@ def load_tn(obj: Any,
 
     # Is it a list of gates?
     if all(map(is_gate, obj)):
+        from tnco.utils.circuit import load
+
         # Convert circuit to tn
-        arrays, ts_inds, output_inds = circuit_utils.load(
-            obj,
-            initial_state=initial_state,
-            final_state=final_state,
-            simplify=simplify_circuit,
-            decompose_hyper_inds=False,
-            fuse=False,
-            atol=atol,
-            seed=seed,
-            verbose=verbose)
+        arrays, ts_inds, output_inds = load(obj,
+                                            initial_state=initial_state,
+                                            final_state=final_state,
+                                            simplify=simplify_circuit,
+                                            decompose_hyper_inds=False,
+                                            fuse=False,
+                                            atol=atol,
+                                            seed=seed,
+                                            verbose=verbose)
 
         # Get tensor network
         tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
@@ -494,18 +494,19 @@ def load_tn(obj: Any,
             obj).__name__ == 'Circuit':
         from cirq import Circuit
 
+        from tnco.utils.circuit import load
+
         if isinstance(obj, Circuit):
             # Convert circuit to tn
-            arrays, ts_inds, output_inds = circuit_utils.load(
-                obj,
-                initial_state=initial_state,
-                final_state=final_state,
-                simplify=simplify_circuit,
-                decompose_hyper_inds=False,
-                fuse=False,
-                atol=atol,
-                seed=seed,
-                verbose=verbose)
+            arrays, ts_inds, output_inds = load(obj,
+                                                initial_state=initial_state,
+                                                final_state=final_state,
+                                                simplify=simplify_circuit,
+                                                decompose_hyper_inds=False,
+                                                fuse=False,
+                                                atol=atol,
+                                                seed=seed,
+                                                verbose=verbose)
 
             # Get tensor network
             tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
@@ -520,18 +521,19 @@ def load_tn(obj: Any,
             obj).__name__ == 'QuantumCircuit':
         from qiskit import QuantumCircuit
 
+        from tnco.utils.circuit import load
+
         if isinstance(obj, QuantumCircuit):
             # Convert circuit to tn
-            arrays, ts_inds, output_inds = circuit_utils.load(
-                obj,
-                initial_state=initial_state,
-                final_state=final_state,
-                simplify=simplify_circuit,
-                decompose_hyper_inds=False,
-                fuse=False,
-                atol=atol,
-                seed=seed,
-                verbose=verbose)
+            arrays, ts_inds, output_inds = load(obj,
+                                                initial_state=initial_state,
+                                                final_state=final_state,
+                                                simplify=simplify_circuit,
+                                                decompose_hyper_inds=False,
+                                                fuse=False,
+                                                atol=atol,
+                                                seed=seed,
+                                                verbose=verbose)
 
             # Get tensor network
             tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,


### PR DESCRIPTION
Libraries like `cirq` are slow to load. Using inline imports to reduce the load time.