### PR TITLE
Fix docstrings

### DIFF
--- a/tnco/app/app.py
+++ b/tnco/app/app.py
@@ -63,7 +63,7 @@ class BaseContractionResults:
             'path'.
         runtime_s: The number of seconds it took to optimize the tensor network
             and get 'path'.
-        path: A path in SSA format with an expected cost of 'cost'.
+        path: A path in linear (einsum) format with an expected cost of 'cost'.
     """
     cost: float
     runtime_s: float

--- a/tnco/app/finite_width/sa.py
+++ b/tnco/app/finite_width/sa.py
@@ -78,8 +78,9 @@ class ContractionResults(BaseContractionResults):
             tensor network for each disconnected path.
         disconnected_paths: The number of total disconnected paths is equal to
             the number of connected components in the optimized tensor network.
-            Each path is in the SSA format and assume that each path is run
-            independently using all the tensors in the original tensor network.
+            Each path is in linear (einsum) format and assume that each
+            path is run independently using all the tensors in the
+            original tensor network.
         disconnected_slices: The set of indices to slice to fit within the
             given width for each disconnected path.
         slices: The set of indices to slice to fit the entire contraction given

--- a/tnco/app/infinite_memory/sa.py
+++ b/tnco/app/infinite_memory/sa.py
@@ -68,8 +68,9 @@ class ContractionResults(BaseContractionResults):
             tensor network for each disconnected path.
         disconnected_paths: The number of total disconnected paths is equal to
             the number of connected components in the optimized tensor network.
-            Each path is in the SSA format and assume that each path is run
-            independently using all the tensors in the original tensor network.
+            Each path is in linear (einsum) format and assume that each
+            path is run independently using all the tensors in the
+            original tensor network.
     """
     disconnected_costs: List[float]
     disconnected_paths: List[List[Tuple[int, int]]]

--- a/tnco/ctree.py
+++ b/tnco/ctree.py
@@ -337,9 +337,9 @@ class ContractionTree(_ContractionTree):
                     its.repeat(dims) if isinstance(dims, int) else dims)))
 
     def path(self) -> List[Tuple[int, int]]:
-        """Return contraction path in SSA format.
+        """Return contraction path in linear (einsum) format.
 
-        Return contraction path in SSA format.
+        Return contraction path in linear (einsum) format.
 
         Returns:
             The contraction path.
@@ -373,7 +373,7 @@ class ContractionTree(_ContractionTree):
             all_pos.pop(pos_[0])
             all_pos.append(z_)
 
-        # Return path in SSA format
+        # Return path in linear (einsum) format
         return path
 
     def max_width(self) -> float:


### PR DESCRIPTION
In general, linear paths (as used in np.einsum) are dynamic paths where tensors are re-indexed every time two tensors are contracted. SSA paths, on the other hand, statically assign an index to all tensors, including the intermediate ones.

This commit fixes the incorrect use of SSA path to linear path (#20).