### PR TITLE
Fix Open Input / Output Qubits When `decompose_hyper_inds=True`

### DIFF
--- a/examples/Optimization.ipynb
+++ b/examples/Optimization.ipynb
@@ -4,16 +4,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "acf69faa-7599-45f4-bf1c-b24902d51b71",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:45.595629Z",
-     "iopub.status.busy": "2025-10-22T14:17:45.595285Z",
-     "iopub.status.idle": "2025-10-22T14:17:48.990866Z",
-     "shell.execute_reply": "2025-10-22T14:17:48.989520Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:45.595587Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from qiskit.circuit.random import random_circuit as qiskit_random_circuit\n",
@@ -42,16 +33,7 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "419f9fee-7426-40e3-80ec-110214ccc55f",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:48.994040Z",
-     "iopub.status.busy": "2025-10-22T14:17:48.993205Z",
-     "iopub.status.idle": "2025-10-22T14:17:49.086797Z",
-     "shell.execute_reply": "2025-10-22T14:17:49.085492Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:48.994003Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The optimizer can be initialized and reused multiple times. The optimization\n",
@@ -80,16 +62,7 @@
    "cell_type": "code",
    "execution_count": 3,
    "id": "1e137412-a6cf-49a0-bb85-3a4bb978abf5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:49.088668Z",
-     "iopub.status.busy": "2025-10-22T14:17:49.088323Z",
-     "iopub.status.idle": "2025-10-22T14:17:49.145410Z",
-     "shell.execute_reply": "2025-10-22T14:17:49.143954Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:49.088639Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# 'tnco.app.Optimizer' accepts multiple format, including 'cirq.Circuit'.\n",
@@ -99,30 +72,14 @@
     "circuit = cirq.testing.random_circuit(qubits=8, n_moments=16, op_density=1)\n",
     "\n",
     "# Get all qubits\n",
-    "qubits = sorted(circuit.all_qubits())\n",
-    "\n",
-    "# The optimizer automatically simplify circuits and automatically decompose\n",
-    "# potential hyper-indices. To keep the final state simple without any\n",
-    "# hyper-index, let's add an initial / final layer of H**0.5, to avoid trivial\n",
-    "# simplifications.\n",
-    "circuit = (cirq.H**0.5).on_each(qubits) + circuit + (cirq.H**\n",
-    "                                                     0.5).on_each(qubits)"
+    "qubits = sorted(circuit.all_qubits())"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "id": "39ebaecc-c0f4-4777-8757-d1e0ed624f02",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:49.146970Z",
-     "iopub.status.busy": "2025-10-22T14:17:49.146684Z",
-     "iopub.status.idle": "2025-10-22T14:17:55.626042Z",
-     "shell.execute_reply": "2025-10-22T14:17:55.624431Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:49.146945Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The optimizer returns the tensor network used for the optimization, and the\n",
@@ -154,27 +111,18 @@
    "cell_type": "code",
    "execution_count": 5,
    "id": "55a0bfc9-2682-4b74-812b-e0d84787472b",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:55.628813Z",
-     "iopub.status.busy": "2025-10-22T14:17:55.627894Z",
-     "iopub.status.idle": "2025-10-22T14:17:55.676619Z",
-     "shell.execute_reply": "2025-10-22T14:17:55.674982Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:55.628760Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "# Infinite Memory| Runtime: 0.0044s\n",
-      "# Infinite Memory| log10(FLOP): 3.7\n",
+      "# Infinite Memory| Runtime: 0.0077s\n",
+      "# Infinite Memory| log10(FLOP): 4.3\n",
       "# -\n",
-      "# Finite Width| Runtime: 0.0044s\n",
-      "# Finite Width| log10(FLOP): 6.1\n",
-      "# Finite Width| Number of sliced indices: 14\n"
+      "# Finite Width| Runtime: 0.0077s\n",
+      "# Finite Width| log10(FLOP): 15\n",
+      "# Finite Width| Number of sliced indices: 41\n"
      ]
     }
    ],
@@ -221,22 +169,14 @@
    "cell_type": "code",
    "execution_count": 6,
    "id": "dfa0238c-9f24-4bfe-bc7d-3009031effb7",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:55.678307Z",
-     "iopub.status.busy": "2025-10-22T14:17:55.677978Z",
-     "iopub.status.idle": "2025-10-22T14:17:55.741161Z",
-     "shell.execute_reply": "2025-10-22T14:17:55.739852Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:55.678275Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The resulting contraction can be contracted using your favorite library.\n",
-    "# Ouput indices in the tensor network are named '(qubit_name, i)', with\n",
-    "# 'qubit_name' being the name of the qubit, and 'i' is zero only if 'qubit_name'\n",
-    "# belongs to the initial state.\n",
+    "# Ouput indices in the tensor network are named '(qubit_name, tag)', with\n",
+    "# 'qubit_name' being the name of the qubit, and 'tag' is 'i' only if\n",
+    "# 'qubit_name' belongs to the initial state, or 'f' only if 'qubit_name' \n",
+    "# belongs to the final state.\n",
     "\n",
     "# Get the exact final state\n",
     "exact_final_state = cirq.Simulator().simulate(\n",
@@ -277,29 +217,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "76e2e4c1-99a3-42fc-aa65-abafdee139dd",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:55.744431Z",
-     "iopub.status.busy": "2025-10-22T14:17:55.744013Z",
-     "iopub.status.idle": "2025-10-22T14:17:58.684500Z",
-     "shell.execute_reply": "2025-10-22T14:17:58.682785Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:55.744399Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Similarly, the optimizer can use 'qiskit.QuantumCircuit' as input\n",
     "\n",
-    "# Implement sqrt of Hadamard\n",
-    "sqrt_H = qiskit.circuit.library.UnitaryGate(cirq.unitary(cirq.H**0.5),\n",
-    "                                            label='√H')\n",
-    "\n",
     "# Get a random circuit\n",
     "qiskit_circuit = qiskit.QuantumCircuit(8)\n",
-    "mit.consume(map(lambda i: qiskit_circuit.append(sqrt_H, [i]), range(8)))\n",
     "qiskit_circuit = qiskit_circuit.compose(qiskit_random_circuit(8, 16))\n",
-    "mit.consume(map(lambda i: qiskit_circuit.append(sqrt_H, [i]), range(8)))\n",
     "\n",
     "# Optimize circuit\n",
     "tn, res = opt.optimize(qiskit_circuit,\n",
@@ -322,16 +247,7 @@
    "cell_type": "code",
    "execution_count": 8,
    "id": "c688e8a4-21ab-44db-ad03-2527e474ba03",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:17:58.686308Z",
-     "iopub.status.busy": "2025-10-22T14:17:58.685998Z",
-     "iopub.status.idle": "2025-10-22T14:18:01.604216Z",
-     "shell.execute_reply": "2025-10-22T14:18:01.602539Z",
-     "shell.execute_reply.started": "2025-10-22T14:17:58.686278Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Instead of using 'cirq.Circuit', it is possible to directly provide a list of\n",
@@ -384,22 +300,13 @@
    "cell_type": "code",
    "execution_count": 9,
    "id": "49e50711-1424-4854-91d2-d8d083c48166",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:18:01.605643Z",
-     "iopub.status.busy": "2025-10-22T14:18:01.605322Z",
-     "iopub.status.idle": "2025-10-22T14:18:04.514317Z",
-     "shell.execute_reply": "2025-10-22T14:18:04.512824Z",
-     "shell.execute_reply.started": "2025-10-22T14:18:01.605612Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/smandra/projects/tnco_v2_clean/tnco/app/app.py:318: UserWarning: Cannot decompose hyper-indices if not all arrays are provided.\n",
+      "/usr/local/google/home/smandra/projects/github/tnco/tnco/app/app.py:322: UserWarning: Cannot decompose hyper-indices if not all arrays are provided.\n",
       "  warn(\"Cannot decompose hyper-indices if not \"\n"
      ]
     }
@@ -450,16 +357,7 @@
    "cell_type": "code",
    "execution_count": 10,
    "id": "22c37c99-898c-4be8-b000-457fb7aa2610",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:18:04.516512Z",
-     "iopub.status.busy": "2025-10-22T14:18:04.516054Z",
-     "iopub.status.idle": "2025-10-22T14:18:04.577039Z",
-     "shell.execute_reply": "2025-10-22T14:18:04.575644Z",
-     "shell.execute_reply.started": "2025-10-22T14:18:04.516479Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Given the optimized path, we can later contract the actual tensors\n",
@@ -495,16 +393,7 @@
    "cell_type": "code",
    "execution_count": 11,
    "id": "dfc49408-85ab-4654-a873-9230c8ba04ce",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:18:04.578408Z",
-     "iopub.status.busy": "2025-10-22T14:18:04.578122Z",
-     "iopub.status.idle": "2025-10-22T14:18:04.618551Z",
-     "shell.execute_reply": "2025-10-22T14:18:04.617595Z",
-     "shell.execute_reply.started": "2025-10-22T14:18:04.578382Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# The optimizer also accepts a list of indices of the format:\n",
@@ -530,16 +419,7 @@
    "cell_type": "code",
    "execution_count": 12,
    "id": "373ed2b8-335c-45fd-81f3-463d3577382c",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:18:04.619841Z",
-     "iopub.status.busy": "2025-10-22T14:18:04.619571Z",
-     "iopub.status.idle": "2025-10-22T14:18:07.500993Z",
-     "shell.execute_reply": "2025-10-22T14:18:07.500044Z",
-     "shell.execute_reply.started": "2025-10-22T14:18:04.619818Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Create a map of indices. To track the location in 'arrays' of the tensors,\n",
@@ -571,16 +451,7 @@
    "cell_type": "code",
    "execution_count": 13,
    "id": "40d60455-d4a8-45ac-936d-8c337451efd5",
-   "metadata": {
-    "execution": {
-     "iopub.execute_input": "2025-10-22T14:18:07.503493Z",
-     "iopub.status.busy": "2025-10-22T14:18:07.503003Z",
-     "iopub.status.idle": "2025-10-22T14:18:07.601253Z",
-     "shell.execute_reply": "2025-10-22T14:18:07.600391Z",
-     "shell.execute_reply.started": "2025-10-22T14:18:07.503455Z"
-    },
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# An easier way would be to load the tensor network first, and then optimize\n",
@@ -659,8 +530,7 @@
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "pygments_lexer": "ipython3"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -86,8 +86,6 @@ def test_LoadTN_CirqCircuit(random_seed):
                                           circuit_depth,
                                           1,
                                           random_state=circuit_seed)
-    circuit = (cirq.H**0.5).on_each(circuit.all_qubits()) + circuit + (
-        cirq.H**0.5).on_each(circuit.all_qubits())
 
     # Get unitary
     U = cirq.unitary(circuit)

--- a/tests/test_circuit.py
+++ b/tests/test_circuit.py
@@ -176,8 +176,6 @@ def test_LoadArbitraryInitialFinalState(random_seed, **kwargs):
                                                   cirq.ISWAP: 2
                                               },
                                               random_state=random_seed)
-    circuit = map((cirq.H**0.5).on, circuit.all_qubits()) + circuit + map(
-        (cirq.H**0.5).on, circuit.all_qubits())
 
     # Get qubits
     qubits = sorted(circuit.all_qubits())
@@ -291,8 +289,6 @@ def test_LoadUnitary(random_seed, **kwargs):
                                                   cirq.ISWAP: 2
                                               },
                                               random_state=random_seed)
-    circuit = map((cirq.H**0.5).on, circuit.all_qubits()) + circuit + map(
-        (cirq.H**0.5).on, circuit.all_qubits())
 
     # Load arrays
     arrays, ts_inds, output_inds = load(
@@ -305,6 +301,10 @@ def test_LoadUnitary(random_seed, **kwargs):
         fuse=fuse,
         use_matrix_commutation=use_matrix_commutation,
         seed=random_seed)
+
+    # All qubits should be present
+    assert output_inds == frozenset(
+        mit.flatten(((q, 'i'), (q, 'f')) for q in circuit.all_qubits()))
 
     # Get exact unitary
     U = cirq.unitary(circuit)
@@ -353,16 +353,10 @@ def test_LoadQisKit(random_seed):
     n_qubits = 6
     circuit_depth = 12
 
-    # Implement sqrt of Hadamard
-    sqrt_H = qiskit.circuit.library.UnitaryGate(cirq.unitary(cirq.H**0.5),
-                                                label='√H')
-
     # Get a random circuit
     circuit = qiskit.QuantumCircuit(n_qubits)
-    mit.consume(map(lambda i: circuit.append(sqrt_H, [i]), range(n_qubits)))
     circuit = circuit.compose(
         random_circuit(n_qubits, circuit_depth, seed=random_seed))
-    mit.consume(map(lambda i: circuit.append(sqrt_H, [i]), range(n_qubits)))
 
     # Get unitary
     U = cirq.unitary(

--- a/tnco/app/app.py
+++ b/tnco/app/app.py
@@ -488,21 +488,19 @@ def load_tn(obj: Any,
                                             verbose=verbose)
 
         # Get tensor network
-        tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
-                               arrays),
-                           output_inds=output_inds)
-
-        # Call back again
-        return load_tn(tn, **options)
+        return TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
+                                 arrays),
+                             output_inds=output_inds)
 
     # Is it a cirq.Circuit? Let's load 'cirq' only if needed.
-    if type(obj).__module__.startswith('cirq.') and type(
-            obj).__name__ == 'Circuit':
-        from cirq import Circuit
+    if type(obj).__module__.startswith('cirq.') and type(obj).__name__ in [
+            'Circuit', 'FrozenCircuit'
+    ]:
+        from cirq import AbstractCircuit
 
         from tnco.utils.circuit import load
 
-        if isinstance(obj, Circuit):
+        if isinstance(obj, AbstractCircuit):
             # Convert circuit to tn
             arrays, ts_inds, output_inds = load(obj,
                                                 initial_state=initial_state,
@@ -515,12 +513,9 @@ def load_tn(obj: Any,
                                                 verbose=verbose)
 
             # Get tensor network
-            tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
-                                   arrays),
-                               output_inds=output_inds)
-
-            # Call back again
-            return load_tn(tn, **options)
+            return TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
+                                     arrays),
+                                 output_inds=output_inds)
 
     # Is it a qiskit.QuantumCircuit? Let's load 'qiskit' only if needed.
     if type(obj).__module__.startswith('qiskit.') and type(
@@ -542,12 +537,9 @@ def load_tn(obj: Any,
                                                 verbose=verbose)
 
             # Get tensor network
-            tn = TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
-                                   arrays),
-                               output_inds=output_inds)
-
-            # Call back again
-            return load_tn(tn, **options)
+            return TensorNetwork(map(lambda xs, a: Tensor(xs, array=a), ts_inds,
+                                     arrays),
+                                 output_inds=output_inds)
 
     # Not a valid object
     raise TypeError("'obj' is not recognized.")


### PR DESCRIPTION
Before this PR, if decompose_hyper_inds=True, some qubits may be missing because they may share an hyper-index with other indices.

This PR fixes #30 by using Kronecker deltas for all the missing open qubits due to sharing hyper-indices with other indices.

Small fixes:
* Use `cirq.AbstractCircuit` instead of `cirq.Circuit` to also allow the use of `cirq.FrozenCircuit`.