### PR TITLE
Add `dtype` and `backend` support to optimizers and centralize RNG

### DIFF
--- a/tnco/app/finite_width/sa.py
+++ b/tnco/app/finite_width/sa.py
@@ -16,7 +16,6 @@ import functools as fts
 import json
 import operator as op
 from dataclasses import dataclass
-from random import Random
 from sys import stderr
 from time import perf_counter
 from typing import Any, FrozenSet, Iterable, List, Optional, Tuple, Union
@@ -149,7 +148,7 @@ class Optimizer(BaseOptimizer):
         tn = self._load_tn(tn, **load_tn_options)
 
         # Initialize random generator
-        rng = Random(self.seed)
+        rng = self._rng
 
         # Check 'n_steps'
         if n_steps is not None:

--- a/tnco/app/infinite_memory/sa.py
+++ b/tnco/app/infinite_memory/sa.py
@@ -14,7 +14,6 @@
 
 import json
 from dataclasses import dataclass
-from random import Random
 from sys import stderr
 from time import perf_counter
 from typing import Any, Iterable, List, Optional, Tuple, Union
@@ -131,7 +130,7 @@ class Optimizer(BaseOptimizer):
         tn = self._load_tn(tn, **load_tn_options)
 
         # Initialize random generator
-        rng = Random(self.seed)
+        rng = self._rng
 
         # Check 'n_steps'
         if n_steps is not None:


### PR DESCRIPTION
- Update `load_tn` and `BaseOptimizer` to support `dtype` and `backend` parameters, allowing for better control over numerical types and integration with different backends via `autoray`.
- Centralize random number generation by adding a shared _rng to BaseOptimizer, ensuring consistent seeding across optimizer implementations.
- Refactor `finite_width` and `infinite_memory` simulated annealing optimizers to use the base class RNG instead of local instances.