### PR TITLE
Fix Kronecker delta creation for immutable backends

### DIFF
--- a/tnco/utils/circuit.py
+++ b/tnco/utils/circuit.py
@@ -288,9 +288,11 @@ def load(circuit: Iterable[Tuple[Matrix, Tuple[Qubit]]],
         """
         Return a Kronecker delta of n-dimensions.
         """
-        delta = ar.do('zeros', 2**n, dtype=dtype, like=backend)
-        delta[[0, -1]] = 1
-        return delta.reshape([2] * n)
+        return ar.do('concatenate', [
+            ar.do('ones', 1, dtype=dtype, like=backend),
+            ar.do('zeros', 2**n - 2, dtype=dtype, like=backend),
+            ar.do('ones', 1, dtype=dtype, like=backend)
+        ]).reshape([2] * n)
 
     # Short names
     same_ = fts.partial(same, atol=atol)


### PR DESCRIPTION
- Replace in-place array assignment with `ar.do('concatenate', ...)` when creating Kronecker deltas in `tnco.utils.circuit.load`.
- This change ensures compatibility with immutable array backends like JAX, which do not support direct item assignment (e.g., `delta[[0, -1]] = 1`).