### PR TITLE
Fix bug in the order in `contraction_cost`, fix header bugs, and missing includes

### DIFF
--- a/include/tnco/assert.hpp
+++ b/include/tnco/assert.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <sstream>
+#include <stdexcept>
 
 namespace tnco {
 

--- a/include/tnco/fixed_float.hpp
+++ b/include/tnco/fixed_float.hpp
@@ -104,7 +104,7 @@ struct FixedFloat {
     return *this;
   }
 
-  auto operator/=(const FixedFloat &x) -> FixedFloat {
+  auto operator/=(const FixedFloat &x) -> FixedFloat & {
     mpfr_div(_x, _x, x._x, rounding);
     return *this;
   }
@@ -575,9 +575,10 @@ void init(py::module &m, const std::string &name) {
            [](const self_type &self, const long double &other) -> auto {
              return self >= other;
            })
-      .def("isinf", [](const self_type &self) -> auto { return isnan(self); })
+      .def("isinf", [](const self_type &self) -> auto { return isinf(self); })
       .def("isnan", [](const self_type &self) -> auto { return isnan(self); })
-      .def("signbit", [](const self_type &self) -> auto { return isnan(self); })
+      .def("signbit",
+           [](const self_type &self) -> auto { return signbit(self); })
       .def(py::pickle(
           [](const self_type &self) -> std::string { return dump(self); },
           [](const std::string &state) -> auto {

--- a/include/tnco/globals.hpp
+++ b/include/tnco/globals.hpp
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <random>
+#include <sstream>
 
 #include "bitset.hpp"
 #include "ctree.hpp"

--- a/include/tnco/node.hpp
+++ b/include/tnco/node.hpp
@@ -19,6 +19,7 @@
 
 #include <array>
 #include <cstdint>
+#include <variant>
 
 namespace tnco::node {
 

--- a/include/tnco/optimize/finite_width/cost_model/base.hpp
+++ b/include/tnco/optimize/finite_width/cost_model/base.hpp
@@ -73,9 +73,9 @@ struct CostModel {
     return std::numeric_limits<width_type>::signaling_NaN();
   }
 
-  [[nodiscard]] virtual auto contraction_cost(const bitset_type &inds_A,
-                                              const bitset_type &inds_B,
-                                              const bitset_type &inds_C,
+  [[nodiscard]] virtual auto contraction_cost(const bitset_type &inds_in1,
+                                              const bitset_type &inds_in2,
+                                              const bitset_type &inds_out,
                                               const dims_type &dims,
                                               const bitset_type &slices) const
       -> cost_type {
@@ -123,8 +123,8 @@ void init(py::module &m, const std::string &name) {
       .def_readonly("max_width", &self_type::max_width)
       .def("width", &self_type::width, "inds"_a, "dims"_a)
       .def("delta_width", &self_type::delta_width, "inds"_a, "dims"_a, "pos"_a)
-      .def("contraction_cost", &self_type::contraction_cost, "inds_A"_a,
-           "inds_B"_a, "inds_C"_a, "dims"_a, "slices"_a)
+      .def("contraction_cost", &self_type::contraction_cost, "inds_in1"_a,
+           "inds_in2"_a, "inds_out"_a, "dims"_a, "slices"_a)
       .def_property_readonly("width_type",
                              [](const self_type &self) -> auto {
                                return type_to_str<width_type>();

--- a/include/tnco/optimize/finite_width/cost_model/simple.hpp
+++ b/include/tnco/optimize/finite_width/cost_model/simple.hpp
@@ -121,23 +121,23 @@ struct CostModel : cost_model::base::CostModel<T...> {
         dims);
   }
 
-  [[nodiscard]] auto contraction_cost(const bitset_type &inds_A,
-                                      const bitset_type &inds_B,
-                                      const bitset_type &inds_C,
+  [[nodiscard]] auto contraction_cost(const bitset_type &inds_in1,
+                                      const bitset_type &inds_in2,
+                                      const bitset_type &inds_out,
                                       const dims_type &dims,
                                       const bitset_type &slices) const
 #ifdef NDEBUG
       noexcept
 #endif
       -> cost_type override {
-    ASSERT(std::size(inds_A) == std::size(inds_B) &&
-               std::size(inds_A) == std::size(inds_C) &&
-               std::size(inds_A) == std::size(slices),
+    ASSERT(std::size(inds_in1) == std::size(inds_in2) &&
+               std::size(inds_in1) == std::size(inds_out) &&
+               std::size(inds_in1) == std::size(slices),
            "Indices  and slices must have the same size.");
-    ASSERT(inds_C.is_subset_of(inds_A | inds_B),
-           "'inds_C' must be a subset of 'inds_A | inds_B'.");
+    ASSERT(inds_out.is_subset_of(inds_in1 | inds_in2),
+           "'inds_out' must be a subset of 'inds_in1 | inds_in2'.");
     return std::visit(
-        [inds = inds_A | inds_B | slices](auto &&dims) -> auto {
+        [inds = inds_in1 | inds_in2 | slices](auto &&dims) -> auto {
           return infinite_memory::cost_model::simple::get_cost<cost_type>(inds,
                                                                           dims);
         },

--- a/include/tnco/optimize/finite_width/cost_model/simple_sparse_inds.hpp
+++ b/include/tnco/optimize/finite_width/cost_model/simple_sparse_inds.hpp
@@ -133,23 +133,23 @@ struct CostModel : simple::CostModel<T...> {
         dims);
   }
 
-  [[nodiscard]] auto contraction_cost(const bitset_type &inds_A,
-                                      const bitset_type &inds_B,
-                                      const bitset_type &inds_C,
+  [[nodiscard]] auto contraction_cost(const bitset_type &inds_in1,
+                                      const bitset_type &inds_in2,
+                                      const bitset_type &inds_out,
                                       const dims_type &dims,
                                       const bitset_type &slices) const
 #ifdef NDEBUG
       noexcept
 #endif
       -> cost_type override {
-    ASSERT(std::size(inds_A) == std::size(inds_B) &&
-               std::size(inds_A) == std::size(inds_C) &&
-               std::size(inds_A) == std::size(slices),
+    ASSERT(std::size(inds_in1) == std::size(inds_in2) &&
+               std::size(inds_in1) == std::size(inds_out) &&
+               std::size(inds_in1) == std::size(slices),
            "Indices  and slices must have the same size.");
-    ASSERT(inds_C.is_subset_of(inds_A | inds_B),
-           "'inds_C' must be a subset of 'inds_A | inds_B'.");
+    ASSERT(inds_out.is_subset_of(inds_in1 | inds_in2),
+           "'inds_out' must be a subset of 'inds_in1 | inds_in2'.");
     return std::visit(
-        [inds = inds_A | inds_B | slices, &sparse_inds = this->sparse_inds,
+        [inds = inds_in1 | inds_in2 | slices, &sparse_inds = this->sparse_inds,
          &n_projs = this->n_projs](auto &&dims) -> auto {
           return infinite_memory::cost_model::simple_sparse_inds::get_cost<
               cost_type>(inds, sparse_inds, n_projs, dims);

--- a/include/tnco/optimize/finite_width/greedy/optimizer.hpp
+++ b/include/tnco/optimize/finite_width/greedy/optimizer.hpp
@@ -188,9 +188,9 @@ struct Optimizer : optimize::optimizer::Optimizer {
       if (new_sliced_width_B <= p_cmodel->max_width) {
         // Get new costs for B and A
         const auto new_ccost_A =
-            cmodel.contraction_cost(inds_A, new_inds_B, inds_E, dims, slices);
+            cmodel.contraction_cost(new_inds_B, inds_E, inds_A, dims, slices);
         const auto new_ccost_B =
-            cmodel.contraction_cost(new_inds_B, inds_D, inds_C, dims, slices);
+            cmodel.contraction_cost(inds_D, inds_C, new_inds_B, dims, slices);
 
         // Get the delta cost
         const auto delta_cost =
@@ -343,11 +343,16 @@ struct Optimizer : optimize::optimizer::Optimizer {
     }
 
     // Check final cost
-    if (const auto rel_error = abs((log(total_cost) - log(get_total_cost())) /
-                                   log(get_total_cost()));
-        rel_error > 1e-2) {
-      throw std::logic_error("Total cost is not properly cached (rel. error: " +
-                             tnco::to_string(rel_error * 100) + "%)");
+    if (const auto actual_total_cost = get_total_cost();
+        actual_total_cost > 0) {
+      if (const auto rel_error =
+              abs((log(total_cost) - log(actual_total_cost)) /
+                  log(actual_total_cost));
+          rel_error > 1e-2) {
+        throw std::logic_error(
+            "Total cost is not properly cached (rel. error: " +
+            tnco::to_string(rel_error * 100) + "%)");
+      }
     }
 #endif
 

--- a/include/tnco/optimize/infinite_memory/cost_model/base.hpp
+++ b/include/tnco/optimize/infinite_memory/cost_model/base.hpp
@@ -45,9 +45,9 @@ struct CostModel {
   auto operator=(CostModel &&) -> CostModel & = delete;
   virtual ~CostModel() = default;
 
-  [[nodiscard]] virtual auto contraction_cost(const bitset_type &inds_A,
-                                              const bitset_type &inds_B,
-                                              const bitset_type &inds_C,
+  [[nodiscard]] virtual auto contraction_cost(const bitset_type &inds_in1,
+                                              const bitset_type &inds_in2,
+                                              const bitset_type &inds_out,
                                               const dims_type &dims) const
       -> cost_type {
     /*
@@ -87,8 +87,8 @@ void init(py::module &m, const std::string &name) {
            [](const self_type &self, const self_type &other) -> auto {
              return true;
            })
-      .def("contraction_cost", &self_type::contraction_cost, "inds_A"_a,
-           "inds_B"_a, "inds_C"_a, "dims"_a)
+      .def("contraction_cost", &self_type::contraction_cost, "inds_in1"_a,
+           "inds_in2"_a, "inds_out"_a, "dims"_a)
       .def_property_readonly("cost_type", [](const self_type &self) -> auto {
         return type_to_str<cost_type>();
       });

--- a/include/tnco/optimize/infinite_memory/cost_model/simple.hpp
+++ b/include/tnco/optimize/infinite_memory/cost_model/simple.hpp
@@ -62,21 +62,21 @@ struct CostModel : cost_model::base::CostModel<T...> {
   using bitset_type = typename base_type::bitset_type;
   using dims_type = typename base_type::dims_type;
 
-  [[nodiscard]] auto contraction_cost(const bitset_type &inds_A,
-                                      const bitset_type &inds_B,
-                                      const bitset_type &inds_C,
+  [[nodiscard]] auto contraction_cost(const bitset_type &inds_in1,
+                                      const bitset_type &inds_in2,
+                                      const bitset_type &inds_out,
                                       const dims_type &dims) const
 #ifdef NDEBUG
       noexcept
 #endif
       -> cost_type override {
-    ASSERT(std::size(inds_A) == std::size(inds_B) &&
-               std::size(inds_A) == std::size(inds_C),
+    ASSERT(std::size(inds_in1) == std::size(inds_in2) &&
+               std::size(inds_in1) == std::size(inds_out),
            "Indices must have the same size.");
-    ASSERT(inds_C.is_subset_of(inds_A | inds_B),
-           "'inds_C' must be a subset of 'inds_A | inds_B'.");
+    ASSERT(inds_out.is_subset_of(inds_in1 | inds_in2),
+           "'inds_out' must be a subset of 'inds_in1 | inds_in2'.");
     return std::visit(
-        [inds = inds_A | inds_B](auto &&dims) -> auto {
+        [inds = inds_in1 | inds_in2](auto &&dims) -> auto {
           return get_cost<cost_type>(inds, dims);
         },
         dims);

--- a/include/tnco/optimize/infinite_memory/cost_model/simple_sparse_inds.hpp
+++ b/include/tnco/optimize/infinite_memory/cost_model/simple_sparse_inds.hpp
@@ -66,21 +66,21 @@ struct CostModel : simple::CostModel<T...> {
     }
   }
 
-  [[nodiscard]] auto contraction_cost(const bitset_type &inds_A,
-                                      const bitset_type &inds_B,
-                                      const bitset_type &inds_C,
+  [[nodiscard]] auto contraction_cost(const bitset_type &inds_in1,
+                                      const bitset_type &inds_in2,
+                                      const bitset_type &inds_out,
                                       const dims_type &dims) const
 #ifdef NDEBUG
       noexcept
 #endif
       -> cost_type override {
-    ASSERT(std::size(inds_A) == std::size(inds_B) &&
-               std::size(inds_A) == std::size(inds_C),
+    ASSERT(std::size(inds_in1) == std::size(inds_in2) &&
+               std::size(inds_in1) == std::size(inds_out),
            "Indices must have the same size.");
-    ASSERT(inds_C.is_subset_of(inds_A | inds_B),
-           "'inds_C' must be a subset of 'inds_A | inds_B'.");
+    ASSERT(inds_out.is_subset_of(inds_in1 | inds_in2),
+           "'inds_out' must be a subset of 'inds_in1 | inds_in2'.");
     return std::visit(
-        [inds = inds_A | inds_B, &sparse_inds = this->sparse_inds,
+        [inds = inds_in1 | inds_in2, &sparse_inds = this->sparse_inds,
          &n_projs = this->n_projs](auto &&dims) -> auto {
           return get_cost<cost_type>(inds, sparse_inds, n_projs, dims);
         },

--- a/include/tnco/optimize/infinite_memory/optimizer.hpp
+++ b/include/tnco/optimize/infinite_memory/optimizer.hpp
@@ -150,9 +150,9 @@ struct Optimizer : optimize::optimizer::Optimizer {
       auto &ccost_A = cost_cache.contraction_cost[pos_A];
       auto &ccost_B = cost_cache.contraction_cost[pos_B];
       const auto new_ccost_A =
-          cmodel.contraction_cost(inds_A, new_inds_B, inds_E, dims);
+          cmodel.contraction_cost(new_inds_B, inds_E, inds_A, dims);
       const auto new_ccost_B =
-          cmodel.contraction_cost(new_inds_B, inds_D, inds_C, dims);
+          cmodel.contraction_cost(inds_D, inds_C, new_inds_B, dims);
 
       // Get the delta cost
       const auto delta_cost = (new_ccost_B - ccost_B) + (new_ccost_A - ccost_A);
@@ -206,11 +206,16 @@ struct Optimizer : optimize::optimizer::Optimizer {
     }
 
     // Check final cost
-    if (const auto rel_error = abs((log(total_cost) - log(get_total_cost())) /
-                                   log(get_total_cost()));
-        rel_error > 1e-2) {
-      throw std::logic_error("Total cost is not properly cached (rel. error: " +
-                             tnco::to_string(rel_error * 100) + "%)");
+    if (const auto actual_total_cost = get_total_cost();
+        actual_total_cost > 0) {
+      if (const auto rel_error =
+              abs((log(total_cost) - log(actual_total_cost)) /
+                  log(actual_total_cost));
+          rel_error > 1e-2) {
+        throw std::logic_error(
+            "Total cost is not properly cached (rel. error: " +
+            tnco::to_string(rel_error * 100) + "%)");
+      }
     }
 #endif
   }

--- a/include/tnco/optimize/infinite_memory/utils.hpp
+++ b/include/tnco/optimize/infinite_memory/utils.hpp
@@ -44,10 +44,10 @@ struct CostCache {
             cache.contraction_cost[pos] = 0;
             cache.partial_cost[pos] = 0;
           } else {
-            const auto &inds_A = ctree.inds[pos];
-            const auto &inds_B = ctree.inds[node.children[0]];
-            const auto &inds_C = ctree.inds[node.children[1]];
-            const auto cost_A = ccost(inds_A, inds_B, inds_C, ctree.dims);
+            const auto &inds_out = ctree.inds[pos];
+            const auto &inds_in1 = ctree.inds[node.children[0]];
+            const auto &inds_in2 = ctree.inds[node.children[1]];
+            const auto cost_A = ccost(inds_in1, inds_in2, inds_out, ctree.dims);
             const auto &pcost_B = cache.partial_cost[node.children[0]];
             const auto &pcost_C = cache.partial_cost[node.children[1]];
             cache.contraction_cost[pos] = cost_A;
@@ -83,10 +83,10 @@ struct HyperCache {
       if (const auto &node = ctree.nodes[pos]; node.is_leaf()) {
         hyper_inds[pos] = bitset_type(n_inds);
       } else {
-        const auto &inds_A = ctree.inds[pos];
-        const auto &inds_B = ctree.inds[node.children[0]];
-        const auto &inds_C = ctree.inds[node.children[1]];
-        hyper_inds[pos] = inds_A & inds_B & inds_C;
+        const auto &inds_out = ctree.inds[pos];
+        const auto &inds_in1 = ctree.inds[node.children[0]];
+        const auto &inds_in2 = ctree.inds[node.children[1]];
+        hyper_inds[pos] = inds_out & inds_in1 & inds_in2;
       }
     }
   }
@@ -106,10 +106,10 @@ template <typename CostType, typename CTree, typename CCost>
   tnco::utils::traverse(
       ctree, [&ctree, &ccost, &total_cost = total_cost](auto &&pos) -> auto {
         if (const auto &node = ctree.nodes[pos]; !node.is_leaf()) {
-          const auto &inds_A = ctree.inds[pos];
-          const auto &inds_B = ctree.inds[node.children[0]];
-          const auto &inds_C = ctree.inds[node.children[1]];
-          total_cost += ccost(inds_A, inds_B, inds_C, ctree.dims);
+          const auto &inds_out = ctree.inds[pos];
+          const auto &inds_in1 = ctree.inds[node.children[0]];
+          const auto &inds_in2 = ctree.inds[node.children[1]];
+          total_cost += ccost(inds_in1, inds_in2, inds_out, ctree.dims);
         }
       });
   return total_cost;

--- a/include/tnco/optimize/prob/mh.hpp
+++ b/include/tnco/optimize/prob/mh.hpp
@@ -49,8 +49,13 @@ struct Probability final : prob::base::Probability<T...> {
 #endif
       -> cost_type override {
     ASSERT(delta_cost <= 0 || (delta_cost / old_cost) >= -1, "Domain error.");
-    return delta_cost <= 0 ? cost_type{1}
-                           : pow(1 + (delta_cost / old_cost), -beta);
+    if (delta_cost <= 0) {
+      return cost_type{1};
+    }
+    if (old_cost == 0) {
+      return cost_type{0};
+    }
+    return pow(1 + (delta_cost / old_cost), -beta);
   }
 
   [[nodiscard]] auto clone() const noexcept -> clone_ptr_type override {

--- a/include/tnco/tree.hpp
+++ b/include/tnco/tree.hpp
@@ -20,6 +20,7 @@
 #include <numeric>
 #include <stack>
 #include <tnco/assert.hpp>
+#include <variant>
 #include <vector>
 
 namespace tnco::tree {

--- a/tnco/optimize/finite_width/cost_model.py
+++ b/tnco/optimize/finite_width/cost_model.py
@@ -272,20 +272,20 @@ class SimpleCostModel(BaseCostModel):
         # Get result
         return core.delta_width(inds, dims, index_pos)
 
-    def contraction_cost(self, inds_A: Iterable[Index], inds_B: Iterable[Index],
-                         inds_C: Iterable[Index], dims: Union[Dict[Index, int],
-                                                              int],
-                         slices: Iterable[Index]) -> float:
+    def contraction_cost(self, inds_in1: Iterable[Index],
+                         inds_in2: Iterable[Index], inds_out: Iterable[Index],
+                         dims: Union[Dict[Index, int],
+                                     int], slices: Iterable[Index]) -> float:
         """Contraction cost.
 
-        Return the cost of contracting 'inds_A' with 'inds_B', to return
-        'inds_C'. It also takes into account any sparse index and the presence
-        of sliced indices.
+        Return the cost of contracting 'inds_in1' with 'inds_in2', to return
+        'inds_out'. It also takes into account any sparse index and the
+        presence of sliced indices.
 
         Args:
-            inds_A: The indices of tensor A.
-            inds_B: The indices of tensor B.
-            inds_C: The indices of the tensor after contracting A with B.
+            inds_in1: The indices of the first tensor.
+            inds_in2: The indices of the second tensor.
+            inds_out: The indices of the tensor after the contraction.
             dims: The dimensions for each index.
             slices: The sliced indices.
 
@@ -297,18 +297,19 @@ class SimpleCostModel(BaseCostModel):
         """
 
         # Convert to tuple
-        inds_A = tuple(inds_A)
-        inds_B = tuple(inds_B)
-        inds_C = tuple(inds_C)
+        inds_in1 = tuple(inds_in1)
+        inds_in2 = tuple(inds_in2)
+        inds_out = tuple(inds_out)
         slices = tuple(slices)
 
-        # inds_C should be a subset of A + B
-        if not frozenset(inds_C).issubset(inds_A + inds_B):
+        # inds_out should be a subset of ind_in1 + inds_in2
+        if not frozenset(inds_out).issubset(inds_in1 + inds_in2):
             raise ValueError(
-                "'inds_C' is not consistent with 'inds_A' and 'inds_B'.")
+                "'inds_out' is not consistent with 'inds_in1' and 'inds_in2'.")
 
         # Get all inds
-        all_inds = tuple(mit.unique_everseen(inds_A + inds_B + inds_C + slices))
+        all_inds = tuple(
+            mit.unique_everseen(inds_in1 + inds_in2 + inds_out + slices))
         if self.sparse_inds is not None:
             all_inds = tuple(
                 mit.unique_everseen(all_inds + tuple(self.sparse_inds)))
@@ -329,12 +330,12 @@ class SimpleCostModel(BaseCostModel):
         core = self.__get_core__(all_inds)
 
         # Convert
-        inds_A, inds_B, inds_C, slices = map(
+        inds_in1, inds_in2, inds_out, slices = map(
             lambda xs: Bitset(map(all_inds.index, xs), len(all_inds)),
-            (inds_A, inds_B, inds_C, slices))
+            (inds_in1, inds_in2, inds_out, slices))
 
         # Get result
-        return core.contraction_cost(inds_A, inds_B, inds_C, dims, slices)
+        return core.contraction_cost(inds_in1, inds_in2, inds_out, dims, slices)
 
     def __get_core__(self, inds_order: Iterable[Index]):
         # Convert

--- a/tnco/optimize/infinite_memory/cost_model.py
+++ b/tnco/optimize/infinite_memory/cost_model.py
@@ -126,19 +126,19 @@ class SimpleCostModel(BaseCostModel):
         """
         return self._n_projs
 
-    def contraction_cost(self, inds_A: Iterable[Index], inds_B: Iterable[Index],
-                         inds_C: Iterable[Index], dims: Union[Dict[Index, int],
-                                                              int]) -> float:
+    def contraction_cost(self, inds_in1: Iterable[Index],
+                         inds_in2: Iterable[Index], inds_out: Iterable[Index],
+                         dims: Union[Dict[Index, int], int]) -> float:
         """Contraction cost.
 
-        Return the cost of contracting 'inds_A' with 'inds_B', to return
-        'inds_C'. It also takes into account any sparse index and the presence
-        of sliced indices.
+        Return the cost of contracting 'inds_in1' with 'inds_in2', to return
+        'inds_out'. It also takes into account any sparse index and the
+        presence of sliced indices.
 
         Args:
-            inds_A: The indices of tensor A.
-            inds_B: The indices of tensor B.
-            inds_C: The indices of the tensor after contracting A with B.
+            inds_in1: The indices of the first tensor.
+            inds_in2: The indices of the second tensor.
+            inds_out: The indices of the tensor after the contraction.
             dims: The dimensions for each index.
 
         Returns:
@@ -149,12 +149,12 @@ class SimpleCostModel(BaseCostModel):
         """
 
         # Convert to tuple
-        inds_A = tuple(inds_A)
-        inds_B = tuple(inds_B)
-        inds_C = tuple(inds_C)
+        inds_in1 = tuple(inds_in1)
+        inds_in2 = tuple(inds_in2)
+        inds_out = tuple(inds_out)
 
         # Get all inds
-        all_inds = tuple(mit.unique_everseen(inds_A + inds_B + inds_C))
+        all_inds = tuple(mit.unique_everseen(inds_in1 + inds_in2 + inds_out))
         if self.sparse_inds is not None:
             all_inds = tuple(
                 mit.unique_everseen(all_inds + tuple(self.sparse_inds)))
@@ -175,12 +175,12 @@ class SimpleCostModel(BaseCostModel):
         core = self.__get_core__(all_inds)
 
         # Convert
-        inds_A, inds_B, inds_C = map(
+        inds_in1, inds_in2, inds_out = map(
             lambda xs: Bitset(map(all_inds.index, xs), len(all_inds)),
-            (inds_A, inds_B, inds_C))
+            (inds_in1, inds_in2, inds_out))
 
         # Get result
-        return core.contraction_cost(inds_A, inds_B, inds_C, dims)
+        return core.contraction_cost(inds_in1, inds_in2, inds_out, dims)
 
     def __get_core__(self, inds_order: Iterable[Index]):
         # Convert


### PR DESCRIPTION
This PR fixes a bug related to the order of arguments in the C++ `contraction_cost` function. This bug was subtle because it wasn't triggering any error and existing unit tests failed to catch it; indeed, for the implemented `SimpleCost`, the order of arguments in C++ does not actually matter. Specifically, `SimpleCost` only depends on the total number of indices, counted once. In principle, the total number of indices should be computed as `inds_in1 | inds_in2`. However, it was previously computed as `inds_in1 | inds_out`. Since `inds_out = (inds_in1 ^ inds_in2) | hyper_inds`, it is easy to show that `inds_in1 | inds_in2 == inds_in1 | inds_out` (or any other permutation).

Other changes:

- Rename `inds_A`, `inds_B`, and `inds_C` to `inds_out`, `inds_in1`, and `inds_in2` in both the C++ and Python cost models for better clarity and consistency.
- Fix copy-paste errors in `isinf` and `signbit` pybind11 bindings for fixed_float, and correct the return type of `operator/=` to `FixedFloat &`.
- Prevent potential division by zero and domain errors in the Metropolis-Hastings probability calculation (`mh.hpp`) and in the relative error validation blocks (`optimizer.hpp`).
- Add missing `<stdexcept>`, `<sstream>`, and `<variant>` standard library includes across various headers (`assert.hpp`, `globals.hpp`, `node.hpp`, `tree.hpp`).