### PR TITLE
Add `get_max_width` to cost models and optimize `is_diagonal`

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -853,3 +853,109 @@ def test_all_close(random_seed: int, **kwargs):
 
     # Logclose should return always false for negative elements
     assert not all_logclose([1, -1, 1], [1, -1, 1])
+
+
+@repeat(40)
+def test_get_max_width(random_seed, **kwargs):
+
+    # Simple cost model setup
+    cmodel = FW_SimpleCostModel(max_width=100.0, cost_type='float64')
+
+    # Edge Case 1: Empty ts_inds
+    assert cmodel.get_max_width([], dims={}) == 0.0
+
+    # Edge Case 2: Single tensor network / Disconnected tensors
+    ts_inds_1 = [[0, 1], [1, 2]]
+    dims_1 = {0: 2, 1: 4, 2: 8}
+
+    # width of first tensor: log2(2*4) = 3
+    # width of second tensor: log2(4*8) = 5
+    # max width should be 5.0
+    assert abs(cmodel.get_max_width(ts_inds_1, dims=dims_1) - 5.0) < 1e-5
+
+    # Edge Case 3: Dimension mapping with int vs dict
+    assert abs(cmodel.get_max_width(ts_inds_1, dims=4) -
+               4.0) < 1e-5  # max is log2(4*4) = 4.0
+
+    # Edge Case 4: Missing dimensions in dims dictionary
+    with pytest.raises(ValueError, match="Some dimensions are missing."):
+        cmodel.get_max_width(ts_inds_1, dims={0: 2})
+
+    # Edge Case 5: Presence of sparse_inds vs absence
+    sparse_inds = [0]
+    cmodel_sparse = FW_SimpleCostModel(max_width=100.0,
+                                       sparse_inds=sparse_inds,
+                                       n_projs=2,
+                                       cost_type='float64')
+    # If a dimension is missing for sparse_inds, it should raise ValueError
+    with pytest.raises(ValueError, match="Some dimensions are missing."):
+        cmodel_sparse.get_max_width([[1, 2]], dims={1: 2, 2: 4})
+
+    # With correct dimensions
+    dims_sparse = {0: 2, 1: 2, 2: 4}
+
+    # width of [1, 2] is log2(2*4) = 3.0, but cost model width
+    # evaluation includes sparse inds internally
+    # width = log2(2*4) = 3.0 (sparse inds generally affect contraction
+    # cost, but `width` also processes them if present)
+    width_val = cmodel_sparse.get_max_width([[1, 2]], dims=dims_sparse)
+    assert isinstance(width_val, float)
+
+    # Initialize Random generator
+    rng = Random(random_seed)
+
+    # Initialize variables
+    n_tensors = kwargs.get('n_tensors', rng.randint(5, 50))
+    n_inds = kwargs.get('n_inds', rng.randint(10, 100))
+    k = kwargs.get('k', rng.randint(2, 5))
+    n_output_inds = kwargs.get('n_output_inds', rng.randint(0, n_inds // 5))
+    n_cc = kwargs.get('n_cc', rng.randint(1, 5))
+    randomize_names = kwargs.get('randomize_names', rng.choice([True, False]))
+
+    try:
+        tensors, output_inds = generate_random_tensors(
+            n_tensors=n_tensors,
+            n_inds=n_inds,
+            k=k,
+            n_output_inds=n_output_inds,
+            n_cc=n_cc,
+            randomize_names=randomize_names,
+            seed=random_seed,
+            verbose=False)
+    except ValueError as e:
+        if str(e) == "Too few indices.":
+            pytest.skip(str(e))
+        raise e
+
+    # Get random dimensions
+    if rng.randrange(2):
+        dims = dict(
+            map(lambda x: (x, rng.randrange(1, 10)),
+                mit.unique_everseen(mit.flatten(tensors))))
+    else:
+        dims = rng.randrange(1, 8)
+
+    # Extract all indices to potentially pick sparse indices
+    all_inds = list(mit.unique_everseen(mit.flatten(tensors)))
+    sparse_inds = rng.sample(all_inds, k=rng.randint(0,
+                                                     len(all_inds) //
+                                                     3)) if all_inds else []
+    n_projs = rng.randint(1, 100) if sparse_inds else None
+
+    # Simple cost model setup
+    cmodel = FW_SimpleCostModel(
+        max_width=rng.random() * 100,
+        sparse_inds=sparse_inds if sparse_inds else None,
+        n_projs=n_projs,
+        cost_type=rng.choice(['float32', 'float64', 'float128', 'float1024']))
+
+    # Compute expected maximum width using width method
+    expected_max_width = 0.0
+    if tensors:
+        expected_max_width = max(cmodel.width(ts, dims) for ts in tensors)
+
+    # Calculate actual max width
+    actual_max_width = cmodel.get_max_width(tensors, dims)
+
+    # Assert correctness
+    assert abs(actual_max_width - expected_max_width) < 1e-5

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1161,14 +1161,19 @@ def test_TNGetEinsumSubscripts(random_seed: int, **kwargs):
     randomize_names = kwargs.get('randomize_names', rng.choice([True, False]))
 
     # Get random tensors
-    ts_inds, output_inds = generate_random_tensors(
-        n_tensors=n_tensors,
-        n_inds=n_inds,
-        k=k,
-        n_output_inds=n_output_inds,
-        n_cc=n_cc,
-        randomize_names=randomize_names,
-        seed=random_seed)
+    try:
+        ts_inds, output_inds = generate_random_tensors(
+            n_tensors=n_tensors,
+            n_inds=n_inds,
+            k=k,
+            n_output_inds=n_output_inds,
+            n_cc=n_cc,
+            randomize_names=randomize_names,
+            seed=random_seed)
+    except ValueError as e:
+        if str(e) == "Too few indices.":
+            pytest.skip(str(e))
+        raise e
 
     # Get all inds
     all_inds = frozenset(mit.flatten(ts_inds))

--- a/tnco/ctree.py
+++ b/tnco/ctree.py
@@ -92,6 +92,9 @@ class ContractionTree(_ContractionTree):
                     "'output_inds' cannot be provided if a contraction "
                     "tree is used instead of a path.")
 
+            if _cache is None:
+                raise RuntimeError("'_cache' must be provided.")
+
             # Get cached positions of relevant tensors
             self._n_tensors = int(_cache[0])
             self._tensors_pos = tuple(_cache[1])

--- a/tnco/optimize/finite_width/cost_model.py
+++ b/tnco/optimize/finite_width/cost_model.py
@@ -14,7 +14,7 @@
 """Cost model for finite width optimization."""
 
 from importlib import import_module
-from typing import Dict, FrozenSet, Iterable, Literal, Optional, Union
+from typing import Dict, FrozenSet, Iterable, List, Literal, Optional, Union
 
 import more_itertools as mit
 
@@ -34,6 +34,9 @@ class BaseCostModel:
         raise NotImplementedError()
 
     def width(*args, **kwargs):
+        raise NotImplementedError()
+
+    def get_max_width(*args, **kwargs):
         raise NotImplementedError()
 
 
@@ -217,6 +220,54 @@ class SimpleCostModel(BaseCostModel):
 
         # Get result
         return core.width(inds, dims)
+
+    def get_max_width(self, ts_inds: Iterable[List[Index]],
+                      dims: Union[Dict[Index, int], int]) -> float:
+        """Return the maximum width of a tensor network.
+
+        It returns the maximum width of a tensors network given its indices and
+        the dimension of each index. It also takes into account the presence of
+        sparse indices.
+
+        Args:
+            ts_inds: The tensor network's indices.
+            dims: The dimensions of each index.
+
+        Returns:
+            The maximum width of the tensor network.
+        """
+
+        # Convert iterator
+        ts_inds = list(ts_inds)
+
+        # Handle empty case
+        if not ts_inds:
+            return 0.0
+
+        # Map all indices
+        all_inds = list(mit.unique_everseen(mit.flatten(ts_inds)))
+        if self.sparse_inds is not None:
+            all_inds = list(
+                mit.unique_everseen(all_inds + list(self.sparse_inds)))
+
+        # Create mapping
+        inds_map = dict((x, i) for i, x in enumerate(all_inds))
+
+        # Try to convert dims to int
+        try:
+            dims = int(dims)
+        except (ValueError, TypeError):
+            dims = tuple(map(dims.get, all_inds))
+            if any(d is None for d in dims):
+                raise ValueError("Some dimensions are missing.")
+
+        # Get core
+        core = self.__get_core__(all_inds)
+
+        # Convert indices, and get maximum width
+        return max(
+            core.width(xs, dims) for xs in (
+                Bitset(map(inds_map.get, xs), len(all_inds)) for xs in ts_inds))
 
     def delta_width(self, inds: Iterable[Index],
                     dims: Union[Dict[Index, int], int], index: Index) -> float:

--- a/tnco/optimize/finite_width/optimizer.py
+++ b/tnco/optimize/finite_width/optimizer.py
@@ -101,11 +101,9 @@ class Optimizer:
 
         # Check that tensors can fit the max allowed width even if some inds
         # are skipped
-        if any(
-                map(
-                    lambda xs: self.cmodel.width(xs & self.skip_slices, ctree.
-                                                 dims) > self.cmodel.max_width,
-                    ctree.inds)):
+        if self.cmodel.get_max_width(
+            (xs & self.skip_slices for xs in ctree.inds),
+                ctree.dims) > self.cmodel.max_width:
             raise ValueError("Too many indices in 'skip_slices'.")
 
         # Convert slices to bitset

--- a/tnco/ordered_frozenset.py
+++ b/tnco/ordered_frozenset.py
@@ -206,7 +206,7 @@ class OrderedFrozenSet:
     def __sub__(self, other: Any) -> 'OrderedFrozenSet':
         if not isinstance(other, (OrderedFrozenSet, set, frozenset)):
             raise TypeError(
-                "unsupported operand type(s) for ^: '{}' and '{}'".format(
+                "unsupported operand type(s) for -: '{}' and '{}'".format(
                     type(self).__name__,
                     type(other).__name__))
         return self.difference(other)
@@ -257,6 +257,6 @@ class OrderedFrozenSet:
         if isinstance(other, (set, frozenset)):
             return self._set == other
         raise TypeError(
-            "unsupported operand type(s) for == '{}' and '{}'".format(
+            "unsupported operand type(s) for ==: '{}' and '{}'".format(
                 type(self).__name__,
                 type(other).__name__))

--- a/tnco/utils/tensor.py
+++ b/tnco/utils/tensor.py
@@ -53,15 +53,15 @@ def is_diagonal(array: Array, /, *, atol: float = 1e-8) -> bool:
     if array.shape[0] != array.shape[1]:
         return False
 
-    # Remove diagonal
-    array = array - ar.do('asarray', [[
-        array[i_, i_] if i_ == j_ else ar.do('zeros', array.shape[2:])
-        for j_ in range(array.shape[0])
-    ]
-                                      for i_ in range(array.shape[1])])
+    # Get dimension
+    n = array.shape[0]
+
+    # Create mask for diagonal elements, and reshape it to be (n, n, 1, 1, ...)
+    # to match array.ndim
+    mask = ar.do('eye', n, like=array).reshape((n, n) + (1,) * (array.ndim - 2))
 
     # Check if all other elements are zero
-    return ar.do('allclose', array, 0, atol=atol)
+    return ar.do('allclose', array * (1 - mask), 0, atol=atol)
 
 
 def decompose_hyper_inds(


### PR DESCRIPTION
This commit introduces a vectorized `get_max_width` method to the finite-width cost models for more efficient width validation and optimizes diagonal checks in tensor utilities.

- Add `get_max_width` to `BaseCostModel` and `SimpleCostModel` to calculate the maximum width of a tensor network directly via bitsets.
- Refactor `Optimizer` initialization to use `get_max_width` for validating `skip_slices` constraints.
- Optimize `is_diagonal` in `tnco/utils/tensor.py` by replacing a nested list comprehension with a masked array operation for better performance.
- Add comprehensive unit tests for `get_max_width` covering edge cases such as empty networks and sparse index mappings.
- Fix typos in `OrderedFrozenSet` error messages for subtraction and equality operators.
- Improve robustness of `test_TNGetEinsumSubscripts` by gracefully skipping cases with insufficient indices.
- Add a safety check in `ContractionTree` to ensure cache availability during initialization.