### PR TITLE
Replace np.einsum with opt_einsum.contract in test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.1.1"
+version = "0.1.2"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1132,7 +1132,7 @@ def test_TensorGetEinsumSubscripts(random_seed):
     output_inds = permutation(output_inds)
 
     # Compute tensordot providing the output inds
-    array_c = np.einsum(
+    array_c = oe.contract(
         tensor_utils.get_einsum_subscripts(inds_a, inds_b, output_inds),
         array_a, array_b)
 
@@ -1197,7 +1197,10 @@ def test_TNGetEinsumSubscripts(random_seed: int, **kwargs):
         pytest.skip("Contraction is too large.")
 
     # Contract using einsum
-    merged_array_1 = oe.contract(subscripts, *arrays, optimize=path)
+    merged_array_1 = oe.contract(subscripts,
+                                 *arrays,
+                                 optimize=path,
+                                 use_blas=True)
 
     # Contract using tnco
     [merged_inds], merged_output_inds, [merged_array_2
@@ -1228,7 +1231,7 @@ def test_Fuse(random_seed, **kwargs):
             # Contract
             arrays.append(
                 Tensor(
-                    np.einsum(
+                    oe.contract(
                         tensor_utils.get_einsum_subscripts(
                             tx.inds, ty.inds, iz), tx.data, ty.data), iz))
 
@@ -2008,7 +2011,7 @@ def test_TensorDot(random_seed):
     # Check operation
     np.testing.assert_allclose(
         az,
-        np.einsum(tensor_utils.get_einsum_subscripts(xs, ys, zs), ax, ay),
+        oe.contract(tensor_utils.get_einsum_subscripts(xs, ys, zs), ax, ay),
         atol=1e-5)
 
     # Check if only inds are returned


### PR DESCRIPTION
* Update test cases in `tests/test_utils.py` to use `opt_einsum.contract`.
* Avoid UnicodeEncodeError with >52 indices in `numpy.einsum` C parser.
* Bump version to `0.1.2` in `pyproject.toml`.

TAG=agy
CONV=f66cefb2-44b6-44af-9226-a4c00894d713