### PR TITLE
Skip tests when index count exceeds NumPy einsum capacity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.1.2"
+version = "0.1.3"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1285,6 +1285,9 @@ def test_Fuse(random_seed, **kwargs):
     if max(map(len, ts_inds)) > 32:
         pytest.skip("Too many indices")
 
+    if len(set(mit.flatten(ts_inds))) > 52:
+        pytest.skip("Too many total indices for einsum backend")
+
     # Set max weight
     max_width = kwargs.get(
         'max_width',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1845,6 +1845,9 @@ def test_Contract(random_seed, **kwargs):
     if max(map(len, ts_inds)) > 32:
         pytest.skip("Too many indices")
 
+    if len(set(mit.flatten(ts_inds))) > 52:
+        pytest.skip("Too many total indices for einsum backend")
+
     # Set max weight
     max_width = kwargs.get(
         'max_width',


### PR DESCRIPTION
* Skip `test_Contract` when total unique indices exceed 52.
* Bump project version to `0.1.3`.