### PR TITLE
Consolidate index hyper-count computation into `get_hyper_count`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.1.4"
+version = "0.2.0"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [

--- a/tests/test_contraction.py
+++ b/tests/test_contraction.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from collections import Counter
 from decimal import Decimal
 import itertools as its
 from os import environ
@@ -30,6 +29,7 @@ from tnco.optimize.infinite_memory.cost_model import \
     SimpleCostModel as IM_SimpleCostModel
 from tnco.optimize.prob import MetropolisHastings
 from tnco.testing.utils import generate_random_tensors
+from tnco.utils.tn import get_hyper_count
 from tnco.utils.tn import get_random_contraction_path
 
 # Initialize RNG
@@ -130,9 +130,7 @@ def test_InfiniteMemoryContraction(random_seed, **kwargs):
         opt.update(mh)
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
+    hyper_count = get_hyper_count(ts_inds)
 
     # Copy the inds
     ts_inds_ = ts_inds[:]
@@ -294,9 +292,7 @@ def test_FiniteWidthContraction(random_seed, **kwargs):
         assert not opt.min_slices & opt.skip_slices
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
+    hyper_count = get_hyper_count(ts_inds)
 
     # Copy the inds
     ts_inds_ = ts_inds[:]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,6 +53,7 @@ from tnco.utils.tn import decompose_hyper_inds as tn_decompose_hyper_inds
 from tnco.utils.tn import fuse
 from tnco.utils.tn import get_connected_components
 from tnco.utils.tn import get_einsum_subscripts
+from tnco.utils.tn import get_hyper_count
 from tnco.utils.tn import get_random_contraction_path
 from tnco.utils.tn import merge_contraction_paths
 from tnco.utils.tn import read_inds
@@ -119,9 +120,7 @@ def test_GenerateRandomTensors(random_seed: int, **kwargs):
     assert isinstance(output_inds, frozenset)
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
+    hyper_count = get_hyper_count(ts_inds)
 
     # All inds with a zero counter must be an output index
     assert frozenset(
@@ -242,13 +241,7 @@ def test_GetRandomContractionPath(random_seed: int, **kwargs):
     cc = get_connected_components(ts_inds)
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
-
-    # Increment hyper-count for hyper-inds
-    for x_ in output_inds:
-        hyper_count[x_] += 1
+    hyper_count = get_hyper_count(ts_inds, output_inds=output_inds)
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
@@ -395,13 +388,7 @@ def test_GetRandomContractionTree(random_seed: int, **kwargs):
     all_inds = frozenset(mit.flatten(ts_inds))
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
-
-    # Add one count for output inds
-    for x_ in output_inds:
-        hyper_count[x_] += 1
+    hyper_count = get_hyper_count(ts_inds, output_inds=output_inds)
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
@@ -2082,3 +2069,80 @@ def test_GetConnectedComponents(random_seed: int, **kwargs):
     # Verify determinism: calling twice with the same input yields identical
     # ordering
     assert cc_actual == get_connected_components(ts_inds, verbose=verbose)
+
+
+@repeat(20)
+def test_get_hyper_count(random_seed: int, **kwargs):
+    # Initialize RNG
+    rng = Random(random_seed)
+
+    # Initialize variables
+    n_tensors = kwargs.get('n_tensors', rng.randint(10, 100))
+    n_inds = kwargs.get('n_inds', rng.randint(20, 200))
+    k = kwargs.get('k', rng.randint(2, 6))
+    n_output_inds = kwargs.get('n_output_inds', rng.randint(0, 30))
+    n_cc = kwargs.get('n_cc', rng.randint(1, 4))
+    randomize_names = kwargs.get('randomize_names', rng.choice([True, False]))
+
+    # Get random tensors
+    try:
+        ts_inds, output_inds = generate_random_tensors(
+            n_tensors,
+            n_inds,
+            k,
+            n_output_inds=n_output_inds,
+            n_cc=n_cc,
+            randomize_names=randomize_names,
+            seed=random_seed)
+    except ValueError as e:
+        if str(e) == "Too few indices.":
+            pytest.skip(str(e))
+        raise e
+
+    # Compute contraction-only hyper count
+    hc_no_out = get_hyper_count(ts_inds)
+
+    # All indices in ts_inds must be present in hc_no_out
+    all_inds = frozenset(mit.flatten(ts_inds))
+    assert frozenset(hc_no_out.keys()) == all_inds
+
+    # Verify non-negativity and domain
+    assert all(c >= 0 for c in hc_no_out.values())
+
+    # Verify maximum contraction count is bounded by k minus 1
+    assert all(c <= k - 1 for c in hc_no_out.values())
+
+    # Verify contraction count formula
+    tensor_counts = Counter(mit.flatten(ts_inds))
+    for idx, count in hc_no_out.items():
+        assert count == tensor_counts[idx] - 1
+
+    # Verify edge and degree sum invariant
+    assert sum(hc_no_out.values()) == sum(map(len, ts_inds)) - len(all_inds)
+
+    # Verify hyper-index and uncontracted index identification
+    for idx, count in hc_no_out.items():
+        if tensor_counts[idx] == 1:
+            assert count == 0
+        if tensor_counts[idx] > 2:
+            assert count > 1
+
+    # Verify effect of output_inds increment
+    hc_with_out = get_hyper_count(ts_inds, output_inds=output_inds)
+    assert frozenset(hc_with_out.keys()) == all_inds | frozenset(output_inds)
+    for idx, count in hc_with_out.items():
+        expected_count = hc_no_out.get(idx,
+                                       0) + (1 if idx in output_inds else 0)
+        assert count == expected_count
+
+    # Verify each hyper-count cannot be larger than k
+    assert all(c <= k for c in hc_with_out.values())
+
+    # Verify index with count k is an output index in k tensors
+    for idx, count in hc_with_out.items():
+        if count == k and k > 0:
+            assert idx in output_inds
+            assert hc_no_out.get(idx, 0) == k - 1
+
+    # Verify determinism
+    assert hc_with_out == get_hyper_count(ts_inds, output_inds=output_inds)

--- a/tnco/app/tn.py
+++ b/tnco/app/tn.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Tensor Network definitions for the application."""
 
-from collections import Counter
 from dataclasses import dataclass
 import itertools as its
 import json
@@ -27,6 +26,7 @@ import more_itertools as mit
 from tnco.typing import Array
 from tnco.typing import Index
 from tnco.typing import Matrix
+from tnco.utils.tn import get_hyper_count
 
 __all__ = ['Tensor', 'TensorNetwork']
 
@@ -235,9 +235,7 @@ class TensorNetwork:
             raise ValueError("Dimensions of 'tensors' are not consistent.")
 
         # Get hyper-count
-        hyper_count = dict(
-            its.starmap(lambda x, n: (x, n - 1),
-                        Counter(mit.flatten(self.ts_inds)).items()))
+        hyper_count = get_hyper_count(self.ts_inds)
 
         if self.output_inds is None:
             # Raise an error if there are hyper-inds but output_inds has not

--- a/tnco/ctree.py
+++ b/tnco/ctree.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Contraction Tree."""
 
-from collections import Counter
 import functools as fts
 import itertools as its
 import math
@@ -32,6 +31,7 @@ from tnco_core.utils import get_contraction
 from tnco_core.utils import traverse
 
 from tnco.typing import Index
+from tnco.utils.tn import get_hyper_count
 
 __all__ = ['ContractionTree', 'traverse_tree']
 
@@ -134,12 +134,8 @@ class ContractionTree(_ContractionTree):
                     mit.flatten(map(lambda x: ts_inds[x], self._tensors_pos))))
 
             # Get hyper-count
-            hyper_count = dict(
-                its.starmap(
-                    lambda x, n: (x, n - 1),
-                    Counter(
-                        mit.flatten(map(lambda x: ts_inds[x],
-                                        self._tensors_pos))).items()))
+            hyper_count = get_hyper_count(
+                map(lambda x: ts_inds[x], self._tensors_pos))
 
             # Get output inds
             if output_inds is None:

--- a/tnco/utils/tn.py
+++ b/tnco/utils/tn.py
@@ -39,7 +39,7 @@ import tnco.utils.tensor as tensor_utils
 __all__ = [
     'get_random_contraction_path', 'get_symbol', 'get_einsum_subscripts',
     'read_inds', 'fuse', 'decompose_hyper_inds', 'merge_contraction_paths',
-    'split_contraction_path', 'contract'
+    'split_contraction_path', 'contract', 'get_hyper_count'
 ]
 
 
@@ -591,6 +591,32 @@ def read_inds(
                         tensor_map.values()))), dims, output_inds, sparse_inds
 
 
+def get_hyper_count(
+        ts_inds: Iterable[Iterable[Index]],
+        output_inds: Optional[Iterable[Index]] = None) -> Dict[Index, int]:
+    """Computes the hyper-count for each index in a tensor network.
+
+    The hyper-count of an index is defined as the number of times it is
+    contracted (the number of tensors it appears in minus one), plus one
+    if it is also an output index.
+
+    Args:
+        ts_inds: List of indices for each tensor.
+        output_inds: Optional collection of output indices. If provided, the
+            count for each output index is incremented by 1.
+
+    Returns:
+        A dictionary mapping each index to its hyper-count.
+    """
+    hyper_count = dict(
+        its.starmap(lambda x, n: (x, n - 1),
+                    Counter(mit.flatten(ts_inds)).items()))
+    if output_inds is not None:
+        for x_ in output_inds:
+            hyper_count[x_] = hyper_count.get(x_, 0) + 1
+    return hyper_count
+
+
 def fuse(
     ts_inds: Iterable[List[Index]],
     dims: Union[int, Dict[Index, int]],
@@ -662,9 +688,7 @@ def fuse(
         return sum(map(math.log2, map(dims.get, xs)))
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds.values())).items()))
+    hyper_count = get_hyper_count(ts_inds.values())
 
     if output_inds is None:
         # Raise an error if there are hyper-inds but output_inds has not been
@@ -988,9 +1012,7 @@ def contract(
                 raise ValueError("'dims' and 'arrays' are not compatible.")
 
     # Get hyper-count
-    hyper_count = dict(
-        its.starmap(lambda x, n: (x, n - 1),
-                    Counter(mit.flatten(ts_inds)).items()))
+    hyper_count = get_hyper_count(ts_inds)
 
     if output_inds is None:
         # Raise an error if there are hyper-inds but output_inds has not been


### PR DESCRIPTION
* Bump version in `pyproject.toml` to `0.2.0`
* Add `get_hyper_count` to `tnco.utils.tn` and export it in `__all__`
* Replace duplicated `Counter` expressions in `fuse` and `contract`
* Use `get_hyper_count` in `ContractionTree` and `TensorNetwork` constructors
* Update `test_contraction` and `test_utils` to use `get_hyper_count`
* Add randomized unit test `test_get_hyper_count` to verify invariants