### PR TITLE
Use `opt_einsum` greedy solver in `get_random_contraction_path`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.3.0"
+version = "0.3.1"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.2.0"
+version = "0.3.0"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [
@@ -48,6 +48,7 @@ dependencies = [
   "autoray",
   "fire",
   "more_itertools",
+  "opt_einsum",
   "pathvalidate",
   "rich"
 ]
@@ -67,7 +68,6 @@ formatting = [
 testing = [
   "cirq",
   "numpy",
-  "opt_einsum",
   "ply",
   "pytest",
   "pytest-repeat",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ build-backend = "scikit_build_core.build"
 [project]
 name = "tnco"
 description = "Tensor Network Contraction Optimizer (TNCO)"
-version = "0.3.1"
+version = "0.3.2"
 readme = "README.md"
 requires-python = ">=3.8"
 authors = [

--- a/tests/test_contraction.py
+++ b/tests/test_contraction.py
@@ -101,6 +101,7 @@ def test_InfiniteMemoryContraction(random_seed, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
@@ -247,6 +248,7 @@ def test_FiniteWidthContraction(random_seed, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -335,6 +335,7 @@ def test_ContractionTree(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(tensors,
+                                        output_inds,
                                         seed=random_seed,
                                         verbose=verbose,
                                         merge_paths=False)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -245,11 +245,13 @@ def test_GetRandomContractionPath(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
     # Calling twice should give the same answer with the same seed
     assert paths == get_random_contraction_path(ts_inds,
+                                                output_inds,
                                                 seed=random_seed,
                                                 merge_paths=False)
 
@@ -327,6 +329,7 @@ def test_GetRandomContractionPath(random_seed: int, **kwargs):
 
     # Get raw contraction
     contractions = get_random_contraction_path(ts_inds,
+                                               output_inds,
                                                seed=random_seed,
                                                _return_contraction=True)
 
@@ -392,6 +395,7 @@ def test_GetRandomContractionTree(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
@@ -631,6 +635,7 @@ def test_OptimizerInfiniteMemory(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
@@ -834,6 +839,7 @@ def test_OptimizerFiniteWidth(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
@@ -1505,6 +1511,7 @@ def test_GetLargestIntermediate(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
     assert len(paths) == 1
@@ -1558,6 +1565,7 @@ def test_DecomposeHyperIndsTN(random_seed: int, **kwargs):
 
     # Get contraction
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
     assert len(paths) == 1
@@ -1682,6 +1690,7 @@ def test_merge_contraction_paths(random_seed, **kwargs):
 
     # Get paths
     paths = get_random_contraction_path(ts_inds,
+                                        output_inds,
                                         seed=random_seed,
                                         merge_paths=False)
 
@@ -1720,16 +1729,18 @@ def test_split_contraction_path(random_seed, **kwargs):
         pytest.skip("Too few indices")
 
     # Get tensors
-    ts_inds, _ = generate_random_tensors(n_tensors=n_tensors,
-                                         n_inds=n_inds,
-                                         k=k,
-                                         n_cc=n_cc,
-                                         n_output_inds=n_output_inds,
-                                         randomize_names=randomize_names,
-                                         seed=random_seed)
+    ts_inds, output_inds = generate_random_tensors(
+        n_tensors=n_tensors,
+        n_inds=n_inds,
+        k=k,
+        n_cc=n_cc,
+        n_output_inds=n_output_inds,
+        randomize_names=randomize_names,
+        seed=random_seed)
 
     # Get path
     path = get_random_contraction_path(ts_inds,
+                                       output_inds,
                                        seed=random_seed,
                                        autocomplete=False)
 

--- a/tnco/app/finite_width/sa.py
+++ b/tnco/app/finite_width/sa.py
@@ -191,6 +191,7 @@ class Optimizer(BaseOptimizer):
 
             # Get random contraction path
             for path in tn_utils.get_random_contraction_path(tn.ts_inds,
+                                                             tn.output_inds,
                                                              merge_paths=False,
                                                              seed=seed):
 

--- a/tnco/app/infinite_memory/sa.py
+++ b/tnco/app/infinite_memory/sa.py
@@ -169,6 +169,7 @@ class Optimizer(BaseOptimizer):
 
             # Get random contraction path
             for path in tn_utils.get_random_contraction_path(tn.ts_inds,
+                                                             tn.output_inds,
                                                              merge_paths=False,
                                                              seed=seed):
 

--- a/tnco/utils/tn.py
+++ b/tnco/utils/tn.py
@@ -22,7 +22,6 @@ import math
 import operator as op
 from random import Random
 from typing import Dict, FrozenSet, Iterable, List, Optional, Tuple, Union
-from warnings import warn
 
 import autoray as ar
 import more_itertools as mit
@@ -109,7 +108,7 @@ def get_connected_components(ts_inds: Iterable[List[Index]],
 
 def get_random_contraction_path(
         ts_inds: Iterable[List[Index]],
-        output_inds: Optional[Iterable[Index]] = None,
+        output_inds: Iterable[Index],
         *,
         merge_paths: bool = True,
         autocomplete: bool = True,
@@ -122,7 +121,7 @@ def get_random_contraction_path(
 
     Args:
         ts_inds: List of indices for each tensor.
-        output_inds: (Deprecated) List of output indices.
+        output_inds: List of output indices.
         merge_paths: If ``True``, merges all paths even if tensors are
             disconnected. If ``False``, returns separate paths for each
             connected component.
@@ -153,40 +152,33 @@ def get_random_contraction_path(
     Examples:
         >>> from tnco.utils.tn import get_random_contraction_path
         >>> ts_inds = [['i', 'j'], ['j', 'k'], ['k', 'l']]
-        >>> get_random_contraction_path(ts_inds, seed=42)
+        >>> get_random_contraction_path(ts_inds, ['i', 'l'], seed=42)
         [(0, 1), (0, 1)]
     """
-    if output_inds is not None:
-        warn(
-            "'output_inds' is deprecated, "
-            "and it will be removed in version '0.2'.",
-            DeprecationWarning,
-            stacklevel=2)
-
     _return_contraction = kwargs.pop('_return_contraction', False)
     if kwargs:
         raise TypeError("Got an expected keyword argument(s).")
 
+    # Initialize random generator and tensor count
     rng = Random(seed)
     ts_inds = list(ts_inds)
     n_tensors = len(ts_inds)
 
-    if output_inds is None:
-        base_hyper_count = get_hyper_count(ts_inds)
-        output_inds_set = OrderedFrozenSet(
-            x for x, count in base_hyper_count.items() if count == 0)
-    else:
-        output_inds_set = OrderedFrozenSet(output_inds)
+    # Process output indices
+    output_inds_set = OrderedFrozenSet(output_inds)
 
+    # Filter connecting hyper-indices from output indices
     hyper_count = get_hyper_count(ts_inds, output_inds=output_inds_set)
     filtered_output_inds = OrderedFrozenSet(
         x for x in output_inds_set if hyper_count.get(x, 0) <= 1)
 
+    # Partition tensors into connected components
     avail_inds_cc = get_connected_components(ts_inds, verbose=verbose)
 
     paths = []
     next_id = n_tensors
 
+    # Compute contraction paths for each connected component
     for i, cc in track(
             enumerate(avail_inds_cc),
             description="Getting contraction paths ...",
@@ -198,6 +190,7 @@ def get_random_contraction_path(
             paths.append([])
             continue
 
+        # Shuffle tensor ordering within component for randomized path finding
         cc_list = list(cc)
         rng.shuffle(cc_list)
 
@@ -208,6 +201,7 @@ def get_random_contraction_path(
         subscripts = get_einsum_subscripts(ts_inds_cc, output_inds_cc)
         shapes = [(2,) * len(xs) for xs in ts_inds_cc]
 
+        # Optimize contraction path with optional progress bar tracking
         with Progress(
                 console=Console(stderr=True),
                 disable=(verbose < 2 or len(ts_inds_cc) <= 1),
@@ -235,6 +229,7 @@ def get_random_contraction_path(
                 optimize=optimize,
             )
 
+        # Map local contraction steps to intermediate node identifiers
         loc = list(cc_list)
         path_cc = []
         for px, py in linear_path_cc:
@@ -250,6 +245,7 @@ def get_random_contraction_path(
     if _return_contraction:
         return paths
 
+    # Convert component contraction paths back to global linear einsum order
     linear_paths = []
     for i, path in enumerate(paths):
         linear_path = []
@@ -268,6 +264,7 @@ def get_random_contraction_path(
             linear_path.append((px, py))
         linear_paths.append(linear_path)
 
+    # Merge paths across components if requested
     return (merge_contraction_paths(
         n_tensors,
         linear_paths,

--- a/tnco/utils/tn.py
+++ b/tnco/utils/tn.py
@@ -44,6 +44,21 @@ __all__ = [
 ]
 
 
+class GreedyProgress(oe.paths.PathOptimizer):
+    """PathOptimizer wrapper supporting a candidate chooser progress
+    callback."""
+
+    def __init__(self, choose_fn):
+        self.choose_fn = choose_fn
+
+    def __call__(self, inputs, output, size_dict, memory_limit=None):
+        return oe.paths.greedy(inputs,
+                               output,
+                               size_dict,
+                               memory_limit=memory_limit,
+                               choose_fn=self.choose_fn)
+
+
 def get_connected_components(ts_inds: Iterable[List[Index]],
                              verbose: int = 0) -> List[List[int]]:
     ts_inds_list = list(ts_inds)
@@ -176,7 +191,7 @@ def get_random_contraction_path(
             enumerate(avail_inds_cc),
             description="Getting contraction paths ...",
             total=len(avail_inds_cc),
-            disable=(verbose <= 0),
+            disable=(verbose != 1),
             console=Console(stderr=True),
     ):
         if len(cc) <= 1:
@@ -192,10 +207,33 @@ def get_random_contraction_path(
 
         subscripts = get_einsum_subscripts(ts_inds_cc, output_inds_cc)
         shapes = [(2,) * len(xs) for xs in ts_inds_cc]
-        linear_path_cc, _ = oe.contract_path(subscripts,
-                                             *shapes,
-                                             shapes=True,
-                                             optimize='greedy')
+
+        with Progress(
+                console=Console(stderr=True),
+                disable=(verbose < 2 or len(ts_inds_cc) <= 1),
+        ) as progress:
+            if verbose >= 2 and len(ts_inds_cc) > 1:
+                task = progress.add_task(
+                    f"Greedy optimization ({i + 1}/{len(avail_inds_cc)}) ...",
+                    total=len(ts_inds_cc) - 1,
+                )
+
+                def choose_fn_with_progress(queue, remaining):
+                    con = oe.paths._simple_chooser(queue, remaining)
+                    if con is not None:
+                        progress.advance(task, 1)
+                    return con
+
+                optimize = GreedyProgress(choose_fn_with_progress)
+            else:
+                optimize = 'greedy'
+
+            linear_path_cc, _ = oe.contract_path(
+                subscripts,
+                *shapes,
+                shapes=True,
+                optimize=optimize,
+            )
 
         loc = list(cc_list)
         path_cc = []

--- a/tnco/utils/tn.py
+++ b/tnco/utils/tn.py
@@ -26,6 +26,7 @@ from warnings import warn
 
 import autoray as ar
 import more_itertools as mit
+import opt_einsum as oe
 from rich.console import Console
 from rich.progress import Progress
 from rich.progress import track
@@ -121,6 +122,19 @@ def get_random_contraction_path(
         component. It is guaranteed that only tensors that share at least one
         index are contracted in connected paths.
 
+    Notes:
+        Hyper-indices that are also output indices are removed from
+        ``output_inds`` before contraction to guarantee that only tensors
+        that share an index are contracted. In ``opt_einsum``'s greedy
+        algorithm, indices listed in ``output_inds`` are ignored as
+        structural contraction edges during its primary inner-product phase
+        (Phase 2). If a connecting hyper-index is left in ``output_inds``,
+        ``opt_einsum`` treats the connected tensors as fragmented and may
+        combine them via arbitrary size-based outer products in Phase 3.
+        Removing hyper-indices from ``output_inds`` ensures ``opt_einsum``
+        treats them as summed-over internal edges, guaranteeing that only
+        tensors sharing at least one index are paired.
+
     Examples:
         >>> from tnco.utils.tn import get_random_contraction_path
         >>> ts_inds = [['i', 'j'], ['j', 'k'], ['k', 'l']]
@@ -134,155 +148,81 @@ def get_random_contraction_path(
             DeprecationWarning,
             stacklevel=2)
 
-    # Extra args
     _return_contraction = kwargs.pop('_return_contraction', False)
     if kwargs:
         raise TypeError("Got an expected keyword argument(s).")
 
-    # Initialize random number generator
     rng = Random(seed)
-
-    # Convert to list
     ts_inds = list(ts_inds)
-
-    # Store the initial number of tensors
     n_tensors = len(ts_inds)
 
-    # First, let's map all indices to ints
-    inds_map = dict(zip(mit.unique_everseen(mit.flatten(ts_inds)), its.count()))
+    if output_inds is None:
+        base_hyper_count = get_hyper_count(ts_inds)
+        output_inds_set = OrderedFrozenSet(
+            x for x, count in base_hyper_count.items() if count == 0)
+    else:
+        output_inds_set = OrderedFrozenSet(output_inds)
 
-    # Remap inds
-    ts_inds = list(map(lambda xs: frozenset(map(inds_map.get, xs)), ts_inds))
+    hyper_count = get_hyper_count(ts_inds, output_inds=output_inds_set)
+    filtered_output_inds = OrderedFrozenSet(
+        x for x in output_inds_set if hyper_count.get(x, 0) <= 1)
 
-    # Get map index->tensors
-    index2tensors = mit.map_reduce(
-        mit.flatten(
-            its.starmap(lambda t, xs: zip(its.repeat(t), xs),
-                        enumerate(ts_inds))), op.itemgetter(1),
-        op.itemgetter(0))
+    avail_inds_cc = get_connected_components(ts_inds, verbose=verbose)
 
-    # Count how many times an index is contracted
-    hyper_count = dict(
-        filter(
-            op.itemgetter(1),
-            zip(index2tensors,
-                map(lambda xs: len(xs) - 1, index2tensors.values()))))
-
-    # Split indices in connected components
-    with Progress(disable=(verbose <= 0),
-                  transient=True,
-                  console=Console(stderr=True)) as progress:
-
-        num_inds = len(inds_map)
-        index_to_tensors = [[] for _ in range(num_inds)]
-
-        task = progress.add_task("Getting connected components ...",
-                                 total=len(ts_inds))
-        for t_id, xs in enumerate(ts_inds):
-            for x in xs:
-                index_to_tensors[x].append(t_id)
-            progress.advance(task)
-
-        avail_inds_cc = list(
-            map(list, get_connected_components(index_to_tensors)))
-
-    # Initialize paths
     paths = []
+    next_id = n_tensors
 
-    # Swap location of two elements in an array
-    def swap(a, x, y):
-        a[x], a[y] = a[y], a[x]
+    for i, cc in track(
+            enumerate(avail_inds_cc),
+            description="Getting contraction paths ...",
+            total=len(avail_inds_cc),
+            disable=(verbose <= 0),
+            console=Console(stderr=True),
+    ):
+        if len(cc) <= 1:
+            paths.append([])
+            continue
 
-    # For each connected components ...
-    for i, avail_inds in enumerate(avail_inds_cc):
-        # Initialize contracted tensors
-        contracted_tensors = set()
+        cc_list = list(cc)
+        rng.shuffle(cc_list)
 
-        # Initialize path
-        path = []
+        ts_inds_cc = [ts_inds[idx] for idx in cc_list]
+        output_inds_cc = filtered_output_inds.intersection(
+            mit.flatten(ts_inds_cc))
 
-        with Progress(disable=(verbose <= 0),
-                      console=Console(stderr=True)) as pbar:
+        subscripts = get_einsum_subscripts(ts_inds_cc, output_inds_cc)
+        shapes = [(2,) * len(xs) for xs in ts_inds_cc]
+        linear_path_cc, _ = oe.contract_path(subscripts,
+                                             *shapes,
+                                             shapes=True,
+                                             optimize='greedy')
 
-            # Size of the progress bar
-            total_pbar = len(avail_inds)
+        loc = list(cc_list)
+        path_cc = []
+        for px, py in linear_path_cc:
+            px, py = sorted((px, py))
+            ty = loc.pop(py)
+            tx = loc.pop(px)
+            tz = next_id
+            next_id += 1
+            loc.append(tz)
+            path_cc.append((tx, ty, tz))
+        paths.append(path_cc)
 
-            # Add progress bar
-            task = pbar.add_task("Getting contraction path ({}/{}) ...".format(
-                i + 1, len(avail_inds_cc)),
-                                 total=total_pbar)
-
-            # While there are available indices
-            while avail_inds:
-                # Select a random index
-                swap(avail_inds, rng.randrange(len(avail_inds)), -1)
-                index = avail_inds[-1]
-
-                # If index has been already fully contracted, skip
-                if index not in hyper_count or len(index2tensors[index]) <= 1:
-                    avail_inds.pop()
-                    continue
-
-                # Get two random tensors
-                tx, ty = rng.sample(list(
-                    filter(lambda t: t not in contracted_tensors,
-                           index2tensors[index])),
-                                    k=2)
-
-                # Get indices
-                xs, ys = ts_inds[tx], ts_inds[ty]
-
-                # Get shared inds
-                shared = xs & ys
-
-                # They should always share an index
-                assert len(shared)
-
-                # Update hyper-count for each shared index
-                for x in shared:
-                    hyper_count[x] -= 1
-                    if hyper_count[x] == 0:
-                        del hyper_count[x]
-
-                # Get new set of indices
-                tz = len(ts_inds)
-                zs = (xs ^ ys).union(filter(lambda x: x in hyper_count, shared))
-
-                # Update inds
-                for x in zs:
-                    index2tensors[x].append(tz)
-
-                # Update tensors
-                contracted_tensors |= {tx, ty}
-                ts_inds.append(zs)
-
-                # Update path
-                path.append((tx, ty, tz))
-
-                # Update pbar
-                pbar.update(task, completed=total_pbar - len(avail_inds))
-
-            # Final update
-            pbar.update(task, completed=total_pbar, refresh=True)
-
-            # Append to all paths
-            paths.append(path)
-
-    # For testing only
     if _return_contraction:
         return paths
 
-    # Normalize paths
     linear_paths = []
     for i, path in enumerate(paths):
         linear_path = []
         loc = list(range(n_tensors))
         for x, y, z in track(
                 path,
-                description="Convert to linear (einsum) path ({}/{}) ...".
-                format(i + 1, len(paths)),
+                description=
+                f"Mapping to original tensor order ({i + 1}/{len(paths)}) ...",
                 disable=(verbose <= 1),
-                console=Console(stderr=True)):
+                console=Console(stderr=True),
+        ):
             px, py = sorted(map(lambda x: bisect_left(loc, x), (x, y)))
             loc.pop(py)
             loc.pop(px)
@@ -290,10 +230,12 @@ def get_random_contraction_path(
             linear_path.append((px, py))
         linear_paths.append(linear_path)
 
-    # Merge paths if needed
-    return merge_contraction_paths(
-        n_tensors, linear_paths, autocomplete=autocomplete, verbose=verbose -
-        1) if merge_paths else linear_paths
+    return (merge_contraction_paths(
+        n_tensors,
+        linear_paths,
+        autocomplete=autocomplete,
+        verbose=verbose - 1,
+    ) if merge_paths else linear_paths)
 
 
 def get_symbol(i: int) -> str:


### PR DESCRIPTION
* Use `opt_einsum.contract_path` in `get_random_contraction_path`
* Add `GreedyProgress` optimizer wrapper for live progress reporting
* Make `output_inds` a mandatory parameter in `get_random_contraction_path`
* Pass `output_inds` across application callers and unit tests
* Bump version to `0.3.2` in `pyproject.toml`